### PR TITLE
Populate blank profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
+# Hi, I'm Kiefer 👋
 
+**QA Engineer & Cybersecurity Professional** — I help SaaS teams ship faster with fewer regressions through security-first test strategy, Playwright automation, and CI-integrated quality systems.
+
+- 🔭 Currently: Software QA Engineer at TCWGlobal (HR Tech & Payroll SaaS)
+- 🎓 M.S. & B.S. Cybersecurity (WGU) · CySA+ · PenTest+ · SSCP
+- 🤖 Building with autonomous Claude Code agent pipelines — 6 side projects shipped in 2026 with full CI gate discipline
+- 🇯🇵 Learning Japanese, open to relocation to Japan
+
+## Featured projects
+
+| Project | What it is |
+| --- | --- |
+| [playwright-framework](https://github.com/kiefertaylorland/playwright-framework) | Enterprise-grade Playwright/TypeScript test automation framework — E2E UI, API, and security discovery testing |
+| [kanto_pokedex](https://github.com/kiefertaylorland/kanto_pokedex) | Modern Gen-I Pokédex — React + Vite + Supabase, with CI gates, E2E, a11y, and security scanning |
+| [test_agent](https://github.com/kiefertaylorland/test_agent) | Human-in-the-loop QA automation agent — FastAPI, plan-then-approve test workflows |
+| [japanese-agent](https://github.com/kiefertaylorland/japanese-agent) | CLI Japanese study tool with spaced repetition for kana, kanji, keigo, and vocab |
+| [hacker-news-japan](https://github.com/kiefertaylorland/hacker-news-japan) | Search and explore Hacker News stories from Japan |
+
+## Toolbox
+
+Playwright · TypeScript · Next.js · Supabase/PostgreSQL (RLS, pgTAP) · Stryker mutation testing · GitHub Actions · Jenkins · Postman/Newman · Claude Code (agentic workflows, custom skills, MCP)
+
+## Reach me
+
+[LinkedIn](https://linkedin.com/in/kieferland) · [GitHub](https://github.com/kiefertaylorland)


### PR DESCRIPTION
The profile README was a single newline byte, so the GitHub profile showed nothing.

Adds: short bio (QA Engineering & Cybersecurity, sourced from the resume repo), featured public projects table, toolbox, and contact links (LinkedIn + GitHub only — no phone/email published).

Draft so you can approve the public-facing copy before it goes live.